### PR TITLE
Automatically compute cubeMapResolution and mipmapLevel.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/nothings/stb.git
 [submodule "thirdparty/slimktx2"]
 	path = thirdparty/slimktx2
-	url = git@github.com:ux3d/slimktx2.git
+	url = https://github.com/ux3d/slimktx2.git

--- a/README.md
+++ b/README.md
@@ -48,17 +48,18 @@ The glTF-IBL-Sampler consists of two projects: lib (shared library) and cli (exe
 The CLI takes an environment HDR image as input. The filtered specular and diffuse cube maps can be stored as KTX1 or KTX2 (with basis compression).
 
 * ```-inputPath```: path to panorama image (default) or cube map (if inputIsCubeMap flag ist set)
-* ```-specularOutput```: output path for specular term of filtered cube map
-* ```-diffuseOutput```: output path for diffuse term of filtered cube map
+* ```-outCubeMap```: output path for filtered cube map (default=outputCubeMap.ktx2)
+* ```-outLUT```: output path for BRDF LUT (default=outputLUT.png)
+* ```-distribution```: NDF to sample (Lambertian, GGX, Charlie)
 * ```-sampleCount```: number of samples used for filtering (default = 1024)
 * ```-mipLevelCount```: number of mip levels of specular cube map
-* ```-cubeMapResolution```: resolution of output cube map (default = 1024)
+* ```-cubeMapResolution```: resolution of output cube map.  If omitted, an optimal resolution is chosen based on the input panorama's resolution.
 * ```-targetFormat```: specify output texture format (R8G8B8A8_UNORM, R16G16B16A16_SFLOAT, R32G32B32A32_SFLOAT)
-* ```-lodBias```: level of detail bias applied to filtering (default = 1 )
-* ```-inputIsCubeMap```: if set, a cube map in ktx1 format is expected at input path 
+* ```-lodBias```: level of detail bias applied to filtering (default = 0)
+* ```-inputIsCubeMap```: if set, a cube map in ktx1 format is expected at input path
 
 Example
 
 ```
-.\cli.exe -inputPath ..\cubemap_in.hdr -inputIsCubeMap -specularOutput ..\..\specular_out.ktx2 -diffuseOutput ..\diffuse_out.ktx2 -sampleCount 1024 -mipLevelCount 5 -cubeMapResolution 1024 -targetFormat R16G16B16A16_SFLOAT
+.\cli.exe -inputPath ..\cubemap_in.hdr
 ```

--- a/README.md
+++ b/README.md
@@ -58,8 +58,14 @@ The CLI takes an environment HDR image as input. The filtered specular and diffu
 * ```-lodBias```: level of detail bias applied to filtering (default = 0)
 * ```-inputIsCubeMap```: if set, a cube map in ktx1 format is expected at input path
 
-Example
+## Example
 
+Generation of the specular environment is achieved by selecting the GGX distribution.
 ```
-.\cli.exe -inputPath ..\cubemap_in.hdr
+.\cli.exe -inputPath ..\cubemap_in.hdr -distribution GGX
+```
+Executing the cli a second time, but with Lambertian distribution will generate a diffuse cubemap.  Diffuse cubemap generation
+ignores mipmapLevelCount (only 1 level is generated). Typical cubeMapResolution used for prefiltered diffuse maps are between 32 and 128 px.
+```
+.\cli.exe -inputPath ..\cubemap_in.hdr -distribution Lambertian -cubeMapResolution 64
 ```

--- a/cli/source/cli.cpp
+++ b/cli/source/cli.cpp
@@ -11,10 +11,10 @@ int main(int argc, char* argv[])
 	const char* pathOutCubeMap = nullptr;
 	const char* pathOutLUT = nullptr;
 	unsigned int sampleCount = 1024u;
-	unsigned int mipLevelCount = 10u;
-	unsigned int cubeMapResolution = 1024u;
-	OutputFormat targetFormat = R16G16B16A16_SFLOAT;
-	Distribution distribution = GGX;
+	unsigned int mipLevelCount = 0u;
+	unsigned int cubeMapResolution = 0u;
+	OutputFormat targetFormat = OutputFormat::R16G16B16A16_SFLOAT;
+	Distribution distribution = Distribution::GGX;
 	float lodBias = 0.0f;
 	bool inputIsCubeMap = false;
 	bool enableDebugOutput = false;
@@ -33,8 +33,8 @@ int main(int argc, char* argv[])
 		printf("-outLUT output path for BRDF LUT\n");
 		printf("-distribution NDF to sample (Lambertian, GGX, Charlie)\n");
 		printf("-sampleCount: number of samples used for filtering (default = 1024)\n");
-		printf("-mipLevelCount: number of mip levels of specular cube map\n");
-		printf("-cubeMapResolution: resolution of output cube map (default = 1024)\n");
+		printf("-mipLevelCount: number of mip levels of specular cube map. If omitted, an optimal mipmap level is chosen, based on the input panorama's resolution.\n");
+		printf("-cubeMapResolution: resolution of output cube map.  If omitted, an optimal resolution is chosen, based on the input panorama's resolution.\n");
 		printf("-targetFormat: specify output texture format (R8G8B8A8_UNORM, R16G16B16A16_SFLOAT, R32G32B32A32_SFLOAT)  \n");
 		printf("-lodBias: level of detail bias applied to filtering (default = 0) \n");
 		printf("-inputIsCubeMap: if set, a cube map in ktx1 format is expected at input path \n");
@@ -75,15 +75,15 @@ int main(int argc, char* argv[])
 
 			if (strcmp(targetFormatString, "R8G8B8A8_UNORM") == 0)
 			{
-				targetFormat = R8G8B8A8_UNORM;
+				targetFormat = OutputFormat::R8G8B8A8_UNORM;
 			}
 			else if (strcmp(targetFormatString, "R16G16B16A16_SFLOAT") == 0)
 			{
-				targetFormat = R16G16B16A16_SFLOAT;
+				targetFormat = OutputFormat::R16G16B16A16_SFLOAT;
 			}
 			else if (strcmp(targetFormatString, "R32G32B32A32_SFLOAT") == 0)
 			{
-				targetFormat = R32G32B32A32_SFLOAT;
+				targetFormat = OutputFormat::R32G32B32A32_SFLOAT;
 			}
 		}
 		else if (strcmp(argv[i], "-distribution") == 0)
@@ -92,15 +92,15 @@ int main(int argc, char* argv[])
 
 			if (strcmp(distributionString, "Lambertian") == 0)
 			{
-				distribution = Lambertian;
+				distribution = Distribution::Lambertian;
 			}
 			else if (strcmp(distributionString, "GGX") == 0)
 			{
-				distribution = GGX;
+				distribution = Distribution::GGX;
 			}
 			else if (strcmp(distributionString, "Charlie") == 0)
 			{
-				distribution = Charlie;
+				distribution = Distribution::Charlie;
 			}
 		}
 		else if (strcmp(argv[i], "-lodBias") == 0)

--- a/lib/include/lib.h
+++ b/lib/include/lib.h
@@ -3,14 +3,14 @@
 
 namespace IBLLib
 {
-	enum OutputFormat
+	enum class OutputFormat
 	{
 		R8G8B8A8_UNORM = 37,
 		R16G16B16A16_SFLOAT = 97,
 		R32G32B32A32_SFLOAT = 109
 	};
 
-	enum Distribution : unsigned int 
+	enum class Distribution : unsigned int 
 	{
 		Lambertian = 0,
 		GGX = 1,

--- a/lib/source/lib.cpp
+++ b/lib/source/lib.cpp
@@ -830,7 +830,8 @@ IBLLib::Result IBLLib::sample(const char* _inputPath, const char* _outputPathCub
 	}
 
 	VkExtent3D panoramaExtent = vulkan.getCreateInfo(panoramaImage)->extent;
-	_cubemapResolution = _cubemapResolution != 0 ? _cubemapResolution : panoramaExtent.height;
+	// it is best to sample an nxn cube map from a 4nx2n equirectangular image, e.g. a 1024x512 equirectangular images becomes a 256x256 cube map.
+	_cubemapResolution = _cubemapResolution != 0 ? _cubemapResolution : panoramaExtent.height / 2;
 	_mipmapCount = _mipmapCount != 0 ? _mipmapCount : static_cast<uint32_t>(floor(log2(_cubemapResolution)));
 
 	const uint32_t cubeMapSideLength = _cubemapResolution;

--- a/lib/source/vkHelper.cpp
+++ b/lib/source/vkHelper.cpp
@@ -570,7 +570,14 @@ VkResult IBLLib::vkHelper::executeCommandBuffers(const std::vector<VkCommandBuff
 
 		if ((res = vkQueueSubmit(m_queue, 1u, &submitInfo, fence)) != VK_SUCCESS)
 		{
-			printf("Failed to submit queue [%u]\n", res);
+			if (res == VK_ERROR_DEVICE_LOST)
+			{
+				printf("Failed to submit queue [VK_ERROR_DEVICE_LOST].  Prefiltering likely exceeded the TDRDelay.  Consider reducing the quality of sample, outputResolution, or mipLevels.\n");
+			}
+			else
+			{
+				printf("Failed to submit queue [%d].\n", res);
+			}
 			vkDestroyFence(m_logicalDevice, fence, nullptr);
 			return res;
 		}


### PR DESCRIPTION
This PR is just some minor usability tweaks.

Provided more helpful output in the event that VK_ERROR_DEVICE_LOST is encountered when submitting commands to the graphics queue.  

Automatically compute optimal cubeMapResolution and mipmapLevel (useful for GGX distribution setting).  Cleaned up README.md documentation on input parameters. 