### PR TITLE
C-style struct FILE is defined in cstdio header

### DIFF
--- a/lib/source/ktxImage.cpp
+++ b/lib/source/ktxImage.cpp
@@ -4,6 +4,8 @@
 #include "DefaultConsoleLogCallback.h"
 #include "DefaultFileIOCallback.h"
 
+#include <cstdio>
+
 IBLLib::KtxImage::KtxImage()
 {
 	ux3d::slimktx2::Callbacks callbacks = 


### PR DESCRIPTION
My compiler complained that the C-style FILE related function are not defined.
According to [cppreference.com](https://en.cppreference.com/w/cpp/io/c) they are defined in `<cstdio>`.

Tested with g++ (Ubuntu 7.5.0-3ubuntu1~18.04) 7.5.0.
